### PR TITLE
make headless converter accept arbitrary srcFormat/dstFormat/converter names

### DIFF
--- a/src/main/java/cubicchunks/converter/headless/HeadlessConverter.java
+++ b/src/main/java/cubicchunks/converter/headless/HeadlessConverter.java
@@ -95,10 +95,10 @@ public class HeadlessConverter {
         }
 
         WorldConverter<?, ?> converter = new WorldConverter<>(
-            Registry.getLevelConverter(context.getInFormat(), context.getOutFormat(), context.getConverterName()).apply(context.getSrcWorld(), context.getDstWorld()),
-            Registry.getReader(context.getInFormat()).apply(context.getSrcWorld(), conf),
-            Registry.getConverter(context.getInFormat(), context.getOutFormat(), context.getConverterName()).apply(conf),
-            Registry.getWriter(context.getOutFormat()).apply(context.getDstWorld())
+            Registry.getLevelConverterById(context.getInFormat(), context.getOutFormat(), context.getConverterName()).apply(context.getSrcWorld(), context.getDstWorld()),
+            Registry.getReaderById(context.getInFormat()).apply(context.getSrcWorld(), conf),
+            Registry.getConverterById(context.getInFormat(), context.getOutFormat(), context.getConverterName()).apply(conf),
+            Registry.getWriterById(context.getOutFormat()).apply(context.getDstWorld())
         );
 
         HeadlessWorker w = new HeadlessWorker(converter, HeadlessConverter::done, () -> failed.set(true));

--- a/src/main/java/cubicchunks/converter/headless/command/HeadlessCommandContext.java
+++ b/src/main/java/cubicchunks/converter/headless/command/HeadlessCommandContext.java
@@ -31,7 +31,7 @@ public class HeadlessCommandContext {
 
     private String inFormat;
     private String outFormat;
-    private String converterName = "Default";
+    private String converterName = "default";
 
     public Path getSrcWorld() {
         return srcWorld;

--- a/src/main/java/cubicchunks/converter/headless/command/commands/InFormatCommand.java
+++ b/src/main/java/cubicchunks/converter/headless/command/commands/InFormatCommand.java
@@ -26,26 +26,24 @@ package cubicchunks.converter.headless.command.commands;
 import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import cubicchunks.converter.headless.command.HeadlessCommandContext;
+import cubicchunks.converter.lib.Registry;
+
+import java.util.stream.StreamSupport;
 
 public class InFormatCommand {
     public static void register(CommandDispatcher<HeadlessCommandContext> dispatcher) {
-        dispatcher.register(LiteralArgumentBuilder.<HeadlessCommandContext>literal("inFormat")
-            .then(LiteralArgumentBuilder.<HeadlessCommandContext>literal("Anvil")
-                .executes((context) -> {
-                    context.getSource().setInFormat("Anvil");
-                    return 1;
-                })
-            ).then(LiteralArgumentBuilder.<HeadlessCommandContext>literal("CubicChunks")
-                .executes((context) -> {
-                    context.getSource().setInFormat("CubicChunks");
-                    return 1;
-                })
-            ).then(LiteralArgumentBuilder.<HeadlessCommandContext>literal("RobintonCubicChunks")
-                .executes((context) -> {
-                    context.getSource().setInFormat("RobintonCubicChunks");
-                    return 1;
-                })
-            )
-        );
+        dispatcher.register(StreamSupport.stream(Registry.getReaders().spliterator(), false)
+                .map(Registry::getReaderClass)
+                .map(Registry::getReaderId)
+                .distinct()
+                .reduce(LiteralArgumentBuilder.literal("inFormat"),
+                        (builder, name) -> builder.then(LiteralArgumentBuilder.<HeadlessCommandContext>literal(name)
+                                .executes(context -> {
+                                    context.getSource().setInFormat(name);
+                                    return 1;
+                                })),
+                        (a, b) -> {
+                            throw new UnsupportedOperationException();
+                        }));
     }
 }

--- a/src/main/java/cubicchunks/converter/lib/Registry.java
+++ b/src/main/java/cubicchunks/converter/lib/Registry.java
@@ -64,7 +64,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 public class Registry {
-    private static final String ID_PATTERN = "[a-z][a-z_0-9.]*";
+    private static final String ID_PATTERN = "[a-z][a-z_0-9]*(:[a-z0-9_.-]+)?";
 
     private static final BiMap<String, BiFunction<Path, ConverterConfig, ? extends ChunkDataReader<?>>> readersByName = Maps.synchronizedBiMap(HashBiMap.create());
     private static final BiMap<String, BiFunction<Path, ConverterConfig, ? extends ChunkDataReader<?>>> readersById = Maps.synchronizedBiMap(HashBiMap.create());
@@ -82,13 +82,13 @@ public class Registry {
 
     static {
         registerReader("Anvil", "anvil", AnvilChunkReader::new, AnvilChunkData.class);
-        registerReader("CubicChunks 1.10 - 1.12", "cubicchunks_1.10_1.12", CubicChunkReader::new, CubicChunksColumnData.class);
+        registerReader("CubicChunks 1.10 - 1.12", "cubicchunks:1.10-1.12", CubicChunkReader::new, CubicChunksColumnData.class);
         registerReader("RobintonCubicChunks", "robinton_cubicchunks", RobintonChunkReader::new, RobintonColumnData.class);
-        registerReader("CubicChunks 1.10 - 1.12 (BigCube)", "cubicchunks_1.10_1.12_bigcube", CubicChunksBigCube112Reader::new, CubicChunksBigCube112Data.class);
+        registerReader("CubicChunks 1.10 - 1.12 (BigCube)", "cubicchunks_bigcube:1.10-1.12", CubicChunksBigCube112Reader::new, CubicChunksBigCube112Data.class);
 
         registerWriter("Anvil", "anvil", AnvilChunkWriter::new, MultilayerAnvilChunkData.class);
-        registerWriter("CubicChunks 1.10 - 1.12", "cubicchunks_1.10_1.12", CubicChunkWriter::new, CubicChunksColumnData.class);
-        registerWriter("CubicChunks 1.17+ (ProtoBigCube)", "cubicchunks_1.17", CubicChunksProtoBigCubeWriter::new, CubicChunksProtoBigCubeData.class);
+        registerWriter("CubicChunks 1.10 - 1.12", "cubicchunks:1.10-1.12", CubicChunkWriter::new, CubicChunksColumnData.class);
+        registerWriter("CubicChunks 1.17+ (ProtoBigCube)", "cubicchunks:1.17", CubicChunksProtoBigCubeWriter::new, CubicChunksProtoBigCubeData.class);
 
         registerConverter("Default", "default", Anvil2CCDataConverter::new, Anvil2CCLevelInfoConverter::new, AnvilChunkData.class, CubicChunksColumnData.class, Anvil2CCDataConverter.class);
         registerConverter("Default", "default", CC2AnvilDataConverter::new, CC2AnvilLevelInfoConverter::new, CubicChunksColumnData.class, MultilayerAnvilChunkData.class, CC2AnvilDataConverter.class);

--- a/src/main/java/cubicchunks/converter/lib/convert/cc2bigCubeCc/Cc2BigCubeCcDataConverter.java
+++ b/src/main/java/cubicchunks/converter/lib/convert/cc2bigCubeCc/Cc2BigCubeCcDataConverter.java
@@ -1,3 +1,26 @@
+/*
+ *  This file is part of CubicChunksConverter, licensed under the MIT License (MIT).
+ *
+ *  Copyright (c) 2017 contributors
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
 package cubicchunks.converter.lib.convert.cc2bigCubeCc;
 
 import cubicchunks.converter.lib.convert.ChunkDataConverter;

--- a/src/main/java/cubicchunks/converter/lib/convert/data/CubicChunksBigCube112Data.java
+++ b/src/main/java/cubicchunks/converter/lib/convert/data/CubicChunksBigCube112Data.java
@@ -1,3 +1,26 @@
+/*
+ *  This file is part of CubicChunksConverter, licensed under the MIT License (MIT).
+ *
+ *  Copyright (c) 2017 contributors
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
 package cubicchunks.converter.lib.convert.data;
 
 import cubicchunks.converter.lib.Dimension;

--- a/src/main/java/cubicchunks/converter/lib/convert/data/CubicChunksProtoBigCubeData.java
+++ b/src/main/java/cubicchunks/converter/lib/convert/data/CubicChunksProtoBigCubeData.java
@@ -1,3 +1,26 @@
+/*
+ *  This file is part of CubicChunksConverter, licensed under the MIT License (MIT).
+ *
+ *  Copyright (c) 2017 contributors
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
 package cubicchunks.converter.lib.convert.data;
 
 import cubicchunks.converter.lib.Dimension;

--- a/src/main/java/cubicchunks/converter/lib/convert/io/CubicChunksBigCube112Reader.java
+++ b/src/main/java/cubicchunks/converter/lib/convert/io/CubicChunksBigCube112Reader.java
@@ -1,3 +1,26 @@
+/*
+ *  This file is part of CubicChunksConverter, licensed under the MIT License (MIT).
+ *
+ *  Copyright (c) 2017 contributors
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
 package cubicchunks.converter.lib.convert.io;
 
 import static cubicchunks.converter.lib.util.Utils.interruptibleConsumer;

--- a/src/main/java/cubicchunks/converter/lib/convert/io/CubicChunksProtoBigCubeWriter.java
+++ b/src/main/java/cubicchunks/converter/lib/convert/io/CubicChunksProtoBigCubeWriter.java
@@ -1,3 +1,26 @@
+/*
+ *  This file is part of CubicChunksConverter, licensed under the MIT License (MIT).
+ *
+ *  Copyright (c) 2017 contributors
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
 package cubicchunks.converter.lib.convert.io;
 
 import cubicchunks.converter.lib.Dimension;

--- a/src/main/java/cubicchunks/converter/lib/util/BigCubeCoords.java
+++ b/src/main/java/cubicchunks/converter/lib/util/BigCubeCoords.java
@@ -1,3 +1,26 @@
+/*
+ *  This file is part of CubicChunksConverter, licensed under the MIT License (MIT).
+ *
+ *  Copyright (c) 2017 contributors
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
 package cubicchunks.converter.lib.util;
 
 import cubicchunks.regionlib.impl.EntryLocation3D;


### PR DESCRIPTION
example usage: `java -jar converter.jar --headless -- 'srcWorld "/path/to/src/world"' 'dstWorld "/path/to/dst/world"' 'inFormat cubicchunks:1.10-1.12' 'outFormat anvil'`