### PR TITLE
use correct unit for vanilla chunk timestamps

### DIFF
--- a/src/main/java/cubicchunks/converter/lib/convert/io/AnvilChunkReader.java
+++ b/src/main/java/cubicchunks/converter/lib/convert/io/AnvilChunkReader.java
@@ -65,7 +65,7 @@ public class AnvilChunkReader extends BaseMinecraftReader<AnvilChunkData, Minecr
                                 .setSectorSize(4096)
                                 .setKeyProvider(keyProvider)
                                 .setRegionKey(regionKey)
-                                .addHeaderEntry(new TimestampHeaderEntryProvider<>(TimeUnit.MILLISECONDS))
+                                .addHeaderEntry(new TimestampHeaderEntryProvider<>(TimeUnit.SECONDS))
                                 .build(),
                         (file, key) -> Files.exists(file)
                 )

--- a/src/main/java/cubicchunks/converter/lib/convert/io/AnvilChunkWriter.java
+++ b/src/main/java/cubicchunks/converter/lib/convert/io/AnvilChunkWriter.java
@@ -73,7 +73,7 @@ public class AnvilChunkWriter implements ChunkDataWriter<MultilayerAnvilChunkDat
                                         .setSectorSize(4096)
                                         .setKeyProvider(keyProvider)
                                         .setRegionKey(regionKey)
-                                        .addHeaderEntry(new TimestampHeaderEntryProvider<>(TimeUnit.MILLISECONDS))
+                                        .addHeaderEntry(new TimestampHeaderEntryProvider<>(TimeUnit.SECONDS))
                                         .build(),
                                 (file, key) -> Files.exists(file)
                         )


### PR DESCRIPTION
vanilla anvil regions' timestamps are in seconds, not milliseconds.